### PR TITLE
security: Fix ImageSharp vulnerability (CVE-2025-54575)

### DIFF
--- a/BadMedicine.Dicom/BadMedicine.Dicom.csproj
+++ b/BadMedicine.Dicom/BadMedicine.Dicom.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="fo-dicom" Version="5.2.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="HIC.SynthEHR" Version="2.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## Security Fix

Addresses **GHSA-rxmq-m78w-7wmc** (CVE-2025-54575) - Moderate severity vulnerability in SixLabors.ImageSharp.

## Vulnerability
- **CVSS**: 5.3 (Moderate)
- **Issue**: Infinite loop in GIF decoder when processing malformed comment extension blocks
- **Impact**: Denial of Service

## Fix
Update SixLabors.ImageSharp: **3.1.7 → 3.1.11**

## Testing
- Build succeeds
- No API changes (patch version)

🤖 Generated with Claude Code