### PR TITLE
fix: Update CI to ubuntu-latest and .NET 8

### DIFF
--- a/.github/workflows/testpack.yml
+++ b/.github/workflows/testpack.yml
@@ -4,16 +4,14 @@ on: push
 
 jobs:
   package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Disable disk flush
         run: sudo apt-get install -y libeatmydata1
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
+          dotnet-version: '8.0.x'
       - name: Start MySQL for testing
         run: sudo systemctl start mysql.service
       - name: Test


### PR DESCRIPTION
## Critical CI Fixes

### Ubuntu Runner
- **From**: ubuntu-20.04
- **To**: ubuntu-latest
- **Reason**: Ubuntu 20.04 deprecated Feb 1, 2025; removed Apr 15, 2025

### .NET Version  
- **From**: .NET 6.0 / 7.0
- **To**: .NET 8.0
- **Reason**: .NET 6 and 7 are EOL

## Impact
Prevents CI failures starting February 2025.

🤖 Generated with Claude Code